### PR TITLE
ped correction

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -84,10 +84,10 @@ RegisterNetEvent("qb-dumpster:client:dumpsterdive", function()
                 elseif i == #searched and not dumpsterFound and not currentlySearching then
                     currentlySearching = true
                     QBCore.Functions.Progressbar("dumpsters", "Searching Dumpster", 4500, false, false, {
-                        disableMovement = false,
-                        disableCarMovement = false,
+                        disableMovement = true,
+                        disableCarMovement = true,
                         disableMouse = false,
-                        disableCombat = false,
+                        disableCombat = true,
                     }, {
                         animDict = "amb@prop_human_bum_bin@base",
                         anim = "base",


### PR DESCRIPTION
freeze character movement and hits while searching the dump, this fixes the animation that allows you to search one dump and quickly go to another, abusing a bug